### PR TITLE
Add pentest environment configuration for AIRMS

### DIFF
--- a/config.json
+++ b/config.json
@@ -12,6 +12,12 @@
         "key_vault_name": "airms-dev-app-kv",
         "backend_cert_name": "airms-{environment}-appgw-backend-cert"
       },
+      "pentest": {
+        "resource_group": "rg-airms-pentest",
+        "cluster_name": "airms-pentest-app-k8s-cluster",
+        "key_vault_name": "airms-pentest-app-kv",
+        "backend_cert_name": "airms-{environment}-appgw-backend-cert"
+      },
       "prod": {
         "resource_group": "mshsclinrsrch01-airms-rgp",
         "cluster_name": "airms-aks",


### PR DESCRIPTION
## Summary
- Add pentest environment configuration to GitHub Actions config
- Enables automated deployments to AIRMS pentest environment

## Configuration
- **Resource Group**: `rg-airms-pentest`
- **AKS Cluster**: `airms-pentest-app-k8s-cluster`
- **Key Vault**: `airms-pentest-app-kv`
- **Backend Cert**: `airms-pentest-appgw-backend-cert`

## Related
- AIRMS-625: Pentest environment deployment preparation
- Follows same pattern as existing dev environment
