### PR TITLE
Add airms demo environment (second instance in the dev cluster)

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,6 +13,13 @@
         "backend_cert_name": "airms-{environment}-appgw-backend-cert",
         "postgres_hostname": "airms-{environment}-app-pg.postgres.database.azure.com"
       },
+      "demo": {
+        "resource_group": "rg-airms-dev",
+        "cluster_name": "airms-dev-app-k8s-cluster",
+        "key_vault_name": "airms-dev-app-kv",
+        "backend_cert_name": "airms-dev-appgw-backend-cert",
+        "postgres_hostname": "airms-dev-app-pg.postgres.database.azure.com"
+      },
       "dev-pub": {
         "resource_group": "rg-airms-{environment}",
         "cluster_name": "airms-{environment}-app-k8s-cluster",


### PR DESCRIPTION
## What

Adds a `demo` environment under `airms.environments` in `config.json`, mapping it to the **existing dev physical resources** (dev cluster, dev Key Vault, dev Postgres, `rg-airms-dev`).

Unlike the other airms environments, the values are **literal dev names** (not `{environment}`-templated), because `demo` is not a separate Azure environment — it is a second, manually-triggered instance of the image annotator running inside the **dev** cluster and sharing dev's Key Vault and Postgres server (isolated by namespace `ia-demo`, a `demo--`-prefixed secret namespace, and its own `image-annotator-backend-demo` database/role).

## Why

The `secrets`, `database`, and `deploy` composite actions resolve the cluster / Key Vault / Postgres / admin-secret / secret names purely from `(project, environment)` via this file. Without a `demo` entry, `environment: demo` falls through to the `default` template and resolves to non-existent `airms-demo-*` / `mshsclinrsrch01-airms-demo-*` names.

This entry lets the image annotator's existing **Seed Secrets** and **Database Creation** workflows (and the deploy) run with `environment: demo` to provision and deploy the demo instance in the dev cluster.

## Consumers (open PRs that depend on this)

- gesundheitscloud/image-annotator-backend#217 — demo option in Seed Secrets / Database Creation / Deploy
- gesundheitscloud/visian-deployment#47 — demo frontend deploy

## Note

Also requires (ops, not in this repo): a `demo--db--postgres--admin` secret in `airms-dev-app-kv` (a copy of `dev--db--postgres--admin`) for the Database Creation workflow.